### PR TITLE
Make dub dependency on unit-threaded accept any version

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -23,7 +23,7 @@
 			  "dub run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d"
 			],
 			"dependencies": {
-			  "unit-threaded": "~>0"
+			  "unit-threaded": "*"
 			},
 			"excludedSourceFiles": [
 			  "source/app.d"


### PR DESCRIPTION
Specifying `"~>0"` as a dependency version cannot be used together with other dub packages that depend on unit-threaded version 1.x or 2.x.