### PR TITLE
Use catch(Throwable) {} in place of deprecated catch {}

### DIFF
--- a/source/ikod/containers/internal.d
+++ b/source/ikod/containers/internal.d
@@ -47,10 +47,10 @@ debug(cachetools) @safe @nogc
             }
             catch(Exception e)
             {
-                () @trusted @nogc nothrow {try{errorf("[%x] %s:%d Exception: %s", Thread.getThis().id(), file, line, e);}catch{}}();
+                () @trusted @nogc nothrow {try{errorf("[%x] %s:%d Exception: %s", Thread.getThis().id(), file, line, e);}catch(Throwable) {}}();
             }
         }
-    }    
+    }
 }
 
 bool UseGCRanges(T)() {


### PR DESCRIPTION
I'd appreciate a tag accompanied with a dub reg sync as usual.

